### PR TITLE
fix undo signal to offundo and onundo

### DIFF
--- a/models.py
+++ b/models.py
@@ -181,7 +181,7 @@ class ACState:
 
 
 class ReserveState:
-    ReserveState_DICT = {"onoff": ("on", "off", "undo")}
+    ReserveState_DICT = {"onoff": ("on", "off", "offundo", "onundo")}
 
     def __init__(self, context):
         self._logFileName = context["reserveStateLogCSVFilePath"]
@@ -273,8 +273,9 @@ class ReserveState:
             return InfraredSignal.sendSignal(signal)
 
     def _makeSignalName(self):
-        if self.onoff == "undo":
-            return "undo"  # TODO: 赤外線信号対応テーブルを作って保守性を高くする
+        if self.onoff == "onundo" or self.onoff == "offundo":
+            return self.onoff
+            # TODO: 赤外線信号対応テーブルを作って保守性を高くする
         elif self.onoff == "on" or self.onoff == "off":
             '''
             信号名
@@ -338,7 +339,10 @@ class UndoReservationForm(ReserveForm):
 
     def change_ReserveState(self, rstate):
         # onoff変更
-        rstate.onoff = "undo"
+        if rstate.onoff == "off":
+            rstate.onoff = "offundo"
+        elif rstate.onoff == "on":
+            rstate.onoff = "onundo"
 
         # 設定時間をセットする
         rstate.settime = 0  # UNDOの場合は0

--- a/test_models.py
+++ b/test_models.py
@@ -74,10 +74,10 @@ class ACStateTest(unittest.TestCase):
 class ReserveStateTest(unittest.TestCase):
     def setUp(self):
         with open(Config.test_context["reserveStateCSVFilePath"], "w") as f:
-            f.write("2016-04-01 13:24:00,undo,0")
+            f.write("2016-04-01 13:24:00,offundo,0")
 
         with open(Config.test_context["reserveStateLogCSVFilePath"], "w") as f:
-            f.write("2016-04-01 13:24:00,undo,0")
+            f.write("2016-04-01 13:24:00,offundo,0")
 
         self.rstate = ReserveState(Config.test_context)
 
@@ -88,16 +88,26 @@ class ReserveStateTest(unittest.TestCase):
     def test_initiate_and_getter(self):
         # test ReserveState initiation
         self.assertEqual(self.rstate.__repr__(),
-                         '<2016-04-01 13:24:00 undo 0>')
+                         '<2016-04-01 13:24:00 offundo 0>')
 
     def test_makeSignalName(self):
         signal = self.rstate._makeSignalName()
-        self.assertEqual(signal, 'undo')
+        self.assertEqual(signal, 'offundo')
 
         self.rstate.onoff = "off"
         self.rstate.settime = 120
         signal = self.rstate._makeSignalName()
         self.assertEqual(signal, 'off02')
+
+        self.rstate.onoff = "on"
+        self.rstate.settime = 180
+        signal = self.rstate._makeSignalName()
+        self.assertEqual(signal, 'on03')
+
+        self.rstate.onoff = "onundo"
+        self.rstate.settime = 0
+        signal = self.rstate._makeSignalName()
+        self.assertEqual(signal, 'onundo')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
予約取り消しのパターンは、切予約と入予約で異なると判明したので、
undoのシグナルを`offundo`と`onundo`で分けるようにした。
